### PR TITLE
add transaction receipt endpoint

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -256,6 +256,34 @@ Resources:
                           AccountsNewRequestPassword: !Ref AccountsNewRequestPassword,
                           PrivateChainAlisTokenAddress: !Ref PrivateChainAlisTokenAddress
                         }
+          /transaction/receipt:
+            post:
+              description: 'トランザクションの詳細を取得する'
+              responses:
+                '200':
+                  description: 'トランザクションの詳細'
+                  schema:
+                    type: object
+                    properties:
+                      transaction_hash:
+                        type: 'string'
+              x-amazon-apigateway-integration:
+                responses:
+                  default:
+                    statusCode: '200'
+                uri: 'http://example.com:8545' # VPC Linkの場合は使用しないが定義する必要のある項目
+                httpMethod: POST
+                type: http
+                connectionId: !Ref PrivateChainVpcLink
+                connectionType: VPC_LINK
+                requestTemplates:
+                  application/json: |
+                    {
+                      "jsonrpc": "2.0",
+                      "method": "eth_getTransactionReceipt",
+                      "params": ["$input.json('transaction_hash').replaceAll('\"','')"],
+                      "id": 1
+                    }
   PrivateSubNet1:
     Type: 'AWS::EC2::Subnet'
     Properties:


### PR DESCRIPTION
## 概要
有料記事購入の際に購入ステータスをユーザーにリアルタイムで伝えるために、トランザクションの承認状況を確認するエンドポイントが必要になったため、この変更を行った。

## 影響範囲(ユーザ)
記事を購入したユーザー

## 影響範囲(システム) 
- プライベートチェーン

## 技術的変更点概要
テンプレートに/transaction/receiptのエンドポイントを追加した。

## 使い方
serverless-applicationのme_articles_purchase_create.pyから
このエンドポイントにJSON-RPCリクエストを行う。

## ブロックチェーンへの影響
プロックチェーンを参照する

## ユーザの財産に関係のあるリリースか
記事購入者のユーザーの購入時のトランザクションを用いる